### PR TITLE
fix: remove regex breaking decryption for merchant tokens

### DIFF
--- a/src/EcDecryptionStrategy.ts
+++ b/src/EcDecryptionStrategy.ts
@@ -45,15 +45,8 @@ export class EcDecryptionStrategy
     const symmetricKey = this.deriveSymmetricKey(sharedSecret);
     const decrypted = this.decryptCiphertext(symmetricKey, data);
 
-    // matches the second close brace and returns everything before and including
-    // the second close brace. we need this because the result often returns with
-    // some random cruft at the end, such as `�d*�<?}ތ0j{��[`
-    const regex = /^[^}]+\}[^}]*\}/gu;
-
-    const match = decrypted.match(regex);
-
     try {
-      return JSON.parse(match[0]);
+      return JSON.parse(decrypted);
     } catch (error) {
       const err = new Error(
         'Unexpected format of decrypted data. Please check payment processing certificate and its private key.'


### PR DESCRIPTION
<!-- Describe your changes in detail -->

## Description

This regex was never confirmed to be necessary and was breaking the decryption of payloads that contained a merchant token.

<!-- Please describe in detail how teammates can test your changes. -->

## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->

### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->

## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
