### PR TITLE
fix: bump node-forge to 1.4.0 to resolve high/critical CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fidm/x509": "^1.2.1",
     "ec-key": "^0.0.6",
-    "node-forge": "^1.3.3"
+    "node-forge": "^1.4.0"
   },
   "devDependencies": {
     "@basis-theory/eslint-config": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7529,10 +7529,10 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-forge@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.3.tgz#0ad80f6333b3a0045e827ac20b7f735f93716751"
-  integrity sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==
+node-forge@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
+  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
 node-gyp-build-optional-packages@5.0.7:
   version "5.0.7"


### PR DESCRIPTION
## Description
- Bump `node-forge` `^1.3.3` → `^1.4.0` to resolve 4 Snyk-flagged vulnerabilities (1 Critical: Improper Certificate Validation; 3 High: Improper Signature Verification x2 + Infinite loop) that were failing the `scan-deps` check.
- Surfaced while validating the ENG-11425 semantic-release migration; the vuln is pre-existing and unrelated to that token change.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change