### PR TITLE
fix: remove orphaned npm-install line breaking the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,6 @@ jobs:
           cache: yarn
           node-version: "22"
 
-      # Removed: node_modules/.bin/npm (from @semantic-release/npm@13.1.5) already satisfies npm >= 11.5.1 for OIDC trusted publishing.
-        run: npm install -g npm@11.18.0 # pinned exact (>= 11.5.1) for OIDC trusted publishing
-
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
         with:


### PR DESCRIPTION
## Description
- The release workflow had an orphaned `run: npm install -g npm@11.18.0` line with no owning step (a partial removal of the "Update npm" step left its `run:` behind and turned the step name into a comment). GitHub rejected the file — "This run likely failed because of a workflow file issue" — so no release could run.
- Remove the dead lines entirely. The global npm upgrade is unnecessary: `@semantic-release/npm@13.1.5` depends on `npm@^11.6.2` and publishes with that bundled npm, which already satisfies the `>= 11.5.1` requirement for OIDC trusted publishing.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change